### PR TITLE
[codex] Add Gmedia maintenance KB and WP7 compatibility guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.config.codekit3
+/graphify-out/
+/docs/superpowers/

--- a/admin/logs.php
+++ b/admin/logs.php
@@ -64,7 +64,7 @@ if ( isset( $_GET['s'] ) ) {
 		$searchand = '';
 
 		foreach ( (array) $search_terms as $search_term ) {
-			$search_term = addslashes_gpc( $search_term );
+			$search_term = wp_slash( $search_term );
 			$log_search  .= "{$searchand}(g.title LIKE '{$n}{$search_term}{$n}') OR (g.description LIKE '{$n}{$search_term}{$n}')";
 			$searchand   = ' AND ';
 		}

--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -1,0 +1,28 @@
+# Gmedia Gallery Knowledge Base
+
+This folder is the source of truth for Gmedia Gallery maintenance docs.
+Selected articles can be mirrored to codeasily.com, but updates should start here.
+
+## Core Docs
+
+- [Architecture](architecture.md)
+- [Release Playbook](release-playbook.md)
+- [Support Playbook](support-playbook.md)
+- [Freemius And Licensing](freemius-and-licensing.md)
+- [Dependency Inventory](dependency-inventory.md)
+- [Upload Flow Reproduction Notes](upload-flow-repro.md)
+
+## Working Rules
+
+- Repo markdown under `docs/kb/` is the documentation source of truth.
+- Do not rely on old root-level markdown notes. Re-check current code, then move useful verified information into `docs/kb/` or delete the stale note.
+- Keep docs practical and tied to current plugin behavior.
+- Prefer small docs that answer a repeated support question.
+- Do not publish license keys, customer personal data, private domains, or exploit details.
+- When codeasily.com content diverges from this folder, update repo markdown first and then mirror it.
+
+## Planned Docs
+
+- `security-inventory.md`
+- `competitors.md`
+- Public how-to articles for upload, albums, galleries, blocks, shortcodes, and troubleshooting.

--- a/docs/kb/architecture.md
+++ b/docs/kb/architecture.md
@@ -1,0 +1,162 @@
+# Architecture
+
+This page is a current-code map for Gmedia Gallery. Re-check code before using it for implementation decisions.
+
+## Entry Point
+
+- `grand-media.php` is the plugin entry point.
+- `gmg_fs()` initializes Freemius from `vendor/freemius/start.php`.
+- Class `Gmedia` wires the plugin lifecycle.
+- `plugins_loaded` calls `Gmedia::start_plugin()`.
+- Activation/deactivation hooks call installer/deactivation paths in `config/setup.php`.
+
+## Core Lifecycle
+
+`Gmedia::__construct()`:
+
+- Checks WordPress requirements.
+- Loads `config.php`.
+- Loads saved options and defines constants/tables.
+- Loads core libraries:
+  - `inc/core.php`
+  - `inc/db.connect.php`
+  - `inc/permalinks.php`
+- Registers scripts, admin/frontend hooks, activation/deactivation, cron schedules, and plugin links.
+
+`Gmedia::start_plugin()`:
+
+- Loads translations and shared helpers.
+- Loads shortcode handling.
+- Branches into admin or frontend behavior.
+
+## Data Model
+
+The plugin uses custom database tables rather than only WordPress posts:
+
+- `gmedia`
+- `gmedia_meta`
+- `gmedia_term`
+- `gmedia_term_meta`
+- `gmedia_term_relationships`
+- `gmedia_log`
+
+Key files:
+
+- `config/setup.php`: default options, install SQL, capabilities, activation/deactivation.
+- `config/update.php`: database upgrade functions.
+- `inc/db.connect.php`: `GmediaDB` data access methods.
+- `inc/core.php`: `GmediaCore` utility methods, upload paths, capabilities, media helpers.
+
+## Admin Surface
+
+Key files:
+
+- `admin/admin.php`: admin menu, admin shell, assets, block editor assets.
+- `admin/class.processor.php`: base processor and admin routing.
+- `admin/processor/*.php`: page-specific processors.
+- `admin/pages/**`: admin page templates.
+- `admin/ajax.php`: admin and frontend AJAX handlers.
+
+Main admin pages:
+
+- Library: `GrandMedia`
+- Add/Import Files: `GrandMedia_AddMedia`
+- Tags: `GrandMedia_Tags`
+- Categories: `GrandMedia_Categories`
+- Albums: `GrandMedia_Albums`
+- Galleries: `GrandMedia_Galleries`
+- Modules: `GrandMedia_Modules`
+- Settings: `GrandMedia_Settings`
+
+## Frontend Surface
+
+Key files:
+
+- `inc/shortcodes.php`: `[gmedia]` and `[gm]` shortcodes.
+- `inc/frontend.filters.php`: frontend metadata, rendering filters, and display helpers.
+- `template/**`: full-page templates for albums, galleries, tags, categories, single items, and comments.
+- `inc/widget.php`: widget support.
+- `inc/post-metabox.php`: editor/post integration.
+- `inc/media-upload.php`: WordPress media modal integration.
+
+## Blocks
+
+Block/editor integration is loaded from admin code:
+
+- `admin/admin.php` hooks `enqueue_block_editor_assets`.
+- `admin/assets/js/gmedia-block.js` is the block script.
+- `admin/assets/css/gmedia-block.css` is the block style.
+
+WordPress.org currently lists these blocks:
+
+- Gmedia Gallery
+- Gmedia Album
+- Gmedia Category
+- Gmedia Tag
+
+## Modules
+
+Gallery modules live under `module/*`.
+
+Typical module files:
+
+- `index.php`
+- `init.php`
+- `settings.php`
+- optional `css/`
+- optional `js/`
+- optional images/assets
+
+Shared module behavior:
+
+- `inc/module.options.php`
+- `admin/pages/modules/**`
+- module dependency loading via the main plugin asset paths.
+
+Do not refactor module skins in bulk. Treat each module as a separate compatibility surface.
+
+## Assets And Dependencies
+
+Bundled assets live under `assets/**` and `admin/assets/**`.
+
+Important dependency areas:
+
+- Bootstrap/Popper
+- Selectize
+- CamanJS image editor
+- noUiSlider
+- Tempus Dominus
+- WaveSurfer
+- jQuery File Tree
+- minicolors
+- Swiper
+- PhotoSwipe
+- Magnific Popup
+- Fancybox
+- Font Awesome
+- plupload queue
+- Spectrum
+
+Dependency updates should start with an inventory issue and module-specific smoke checks.
+
+## Freemius And Licensing
+
+Use [Freemius And Licensing](freemius-and-licensing.md) as the source of truth.
+
+High-level flow:
+
+- Freemius initializes in `grand-media.php`.
+- License helper functions live in `inc/functions.php`.
+- License UI lives in `admin/pages/settings/tpl/license.php`.
+- Settings processing lives in `admin/processor/class.processor.settings.php`.
+- Module access checks use `gmedia_has_premium_license()`.
+
+## External And Optional Integrations
+
+- Yoast sitemap integration uses `inc/sitemap.php` when relevant.
+- App/mobile service helpers live under `app/**`.
+- Image EXIF handling uses bundled PEL under `inc/pel/**`.
+
+## Verification Rule
+
+This document is a navigation aid, not proof. Before changing a behavior, verify the exact current code path with `rg`, file reads, and local WordPress smoke tests.

--- a/docs/kb/dependency-inventory.md
+++ b/docs/kb/dependency-inventory.md
@@ -1,0 +1,83 @@
+# Dependency Inventory
+
+Last checked: 2026-06-05
+
+This page tracks bundled JavaScript and CSS dependencies that should be understood before any compatibility, security, or UI refresh work. It is an inventory only: no upgrades were made while creating this document.
+
+## Rules
+
+- Re-check current code before upgrading any dependency.
+- Prefer one dependency upgrade per ticket unless a pair must move together.
+- For user-facing dependencies, test at least one real gallery on the frontend.
+- For admin dependencies, test the exact admin page and mode that enqueues the asset.
+- Treat locally present ignored module folders as module package inventory, not committed core source, until their release ownership is clarified.
+- Do not publish detailed security claims from this page without validation.
+
+## Core And Admin Dependencies
+
+| Dependency | Bundled version | Registered/enqueued from | Surface | Current usage | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| Bootstrap | 5.1.3 | `grand-media.php`, `admin/admin.php`, `inc/media-upload.php` | Admin, media popup | Base admin styles/scripts; `bootstrap.bundle` also includes Popper for Bootstrap components. | Keep short-term. Upgrade only with full admin smoke tests because many plugin screens depend on Bootstrap markup and behaviors. |
+| Popper | 2.11.2 | `admin/admin.php` | Admin | Separate Popper handle for edit screens using Tempus Dominus. Bootstrap bundle also contains Popper. | Keep short-term. Review duplicate Popper loading before any Bootstrap/Tempus Dominus upgrade. |
+| Selectize | 0.13.5 | `admin/admin.php`, `inc/media-upload.php` | Admin, media popup | Term/tag selectors and media upload popup fields. | Review/update after Add Media, edit media, and media popup tests exist. Replacement would be a separate UX ticket. |
+| Spectrum | 1.8.0 | `admin/admin.php` | Admin | Color picker on gallery/module settings screens. | Review together with minicolors. Update only after module settings smoke tests. |
+| CamanJS | 4.1.2 | `admin/admin.php` | Admin image editor | Image editor when `gmediablank=image_editor`. | High-risk legacy dependency. Keep until image editor behavior is covered, then evaluate replacement or isolation. |
+| noUiSlider | 6.1.0 | `admin/admin.php`, `assets/image-editor/js/jquery.nouislider.min.js` | Admin image editor | Slider controls inside the image editor. | Keep with CamanJS for now. Any upgrade belongs with the image editor test/replacement work. |
+| Tempus Dominus | 6.0.0 in WordPress registration, header says `v6.0.0-beta5.1` | `admin/admin.php` | Admin | Date/time fields on media edit and album edit screens. | Verify exact source/version before upgrade. Pair with Popper and date-field tests. |
+| WaveSurfer | Admin registered as 1.1.5, frontend registered as 1.2.8; bundled file has no obvious version header | `admin/admin.php`, `grand-media.php` | Admin, frontend modules | Admin audio waveform behavior and WaveSurfer gallery modules. | Reconcile version mismatch before upgrade. Test admin audio metadata and frontend WaveSurfer module. |
+| jQuery File Tree | Registered as 1.0.1, file header says 1.01 | `admin/admin.php` | Admin import | Server import folder browser. | High-priority review with import-path hardening and upload/import smoke tests. |
+| jQuery Minicolors | 0.9.13 in WordPress registration; file header has no version | `admin/admin.php` | Admin | Color controls on gallery/module settings screens. | Review with Spectrum. Replacement/update should wait for module settings smoke tests. |
+| plupload queue | 2.3.9 in WordPress registration; bundled wrapper file has no version header | `admin/admin.php`, `inc/media-upload.php` | Admin upload, media popup | Upload queue UI around WordPress `plupload`. | High-priority compatibility review with upload-flow work. Do not change without Add Media and popup upload tests. |
+| Font Awesome | 6.1.1 | `grand-media.php` | Admin | Admin icon font used by Gmedia admin UI. | Keep short-term. Update with visual admin smoke tests. |
+
+## Frontend And Module Dependencies
+
+| Dependency | Bundled version | Registered/enqueued from | Surface | Current usage | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| Swiper | 5.3.6 | `grand-media.php`; module `dependencies` fields | Frontend modules | Used by `phototravlr`, `desire`, `photomania`, `c1slider`, and codecanyon `phototravlr` modules. | Upgrade module-by-module. Swiper major versions have API and markup changes, so do not bundle this into unrelated releases. |
+| PhotoSwipe | 3.0.5 | `grand-media.php` | Frontend lightbox | Registered globally for modules that depend on the `photoswipe` handle. | Legacy lightbox. Update only after identifying exact modules and frontend gallery smoke tests. |
+| Magnific Popup | 1.1.0 in `assets/mag-popup` header | Asset folder exists; codecanyon `cubik` declares `magnific-popup` dependency; no core `wp_register_script` for this handle was found | Frontend modules | Several ignored local module scripts include Magnific Popup code headers, and codecanyon `cubik` declares the handle. | Verify module packaging. Either register the handle intentionally or remove stale dependency declarations if module scripts vendor the code directly. |
+| Fancybox | 1.3.4 | `grand-media.php` | Frontend lightbox | Registered as `fancybox` with `easing` dependency. | Legacy-only. Replace only after identifying affected gallery modules and creating visual regression checks. |
+| WaveSurfer | Admin 1.1.5, frontend 1.2.8 | `grand-media.php`; `wavesurfer` module dependencies | Frontend audio modules | Used by `wavesurfer` and codecanyon `wavesurfer` modules. | Same action as admin WaveSurfer: reconcile versions first, then test admin and frontend audio paths. |
+| jPlayer | 2.6.4 | `grand-media.php`; `jq-mplayer` module dependency | Frontend audio module | Used by `jq-mplayer`. | Keep until audio module ownership is clarified. Consider replacement only as a dedicated module modernization ticket. |
+| Mousetrap | 1.5.2 | `grand-media.php`; module `dependencies` fields | Frontend modules | Keyboard controls in `phototravlr`, `desire`, `photomania`, and codecanyon `phototravlr`. | Keep short-term. Upgrade with keyboard navigation tests for those modules. |
+| Velocity | 1.4.1 | `grand-media.php` | Frontend modules | Registered globally for frontend module use. | Inventory exact module usage before changing. |
+| jQuery Easing | 1.3.0 | `grand-media.php` | Frontend lightbox | Dependency of Fancybox registration. | Keep with Fancybox until Fancybox is replaced or removed. |
+| WordPress media scripts | WordPress core-provided | `wp-videoplayer` module dependency field | Frontend module | `wp-util`, `backbone`, and `mediaelement` handles are declared by `wp-videoplayer`. | Keep as WordPress-provided dependencies. Verify against the latest supported WordPress before module changes. |
+| SWFObject / SWFAddress | No bundled JS files found in current repo scan | `green-style` module dependency field; `template/functions.php` deregisters `swfaddress` for iframe mode | Legacy/Flash module | `green-style` references Flash/SWF behavior. | Treat as legacy. Create a dedicated ticket to decide whether GreenStyle Pro remains supported or should be retired/hidden. |
+
+## Module Dependency Handles Observed
+
+Current local scan with ignored module folders included found these non-empty module dependency declarations:
+
+| Handles | Modules |
+| --- | --- |
+| `swiper` | `c1slider` |
+| `swiper,mousetrap` | `phototravlr`, `desire`, `photomania`, `codecanyon/phototravlr` |
+| `wavesurfer` | `wavesurfer`, `codecanyon/wavesurfer` |
+| `jplayer` | `jq-mplayer` |
+| `wp-util,backbone,mediaelement` | `wp-videoplayer` |
+| `magnific-popup` | `codecanyon/cubik` |
+| `swfobject,swfaddress` | `green-style` |
+
+Many module folders and module zip files are ignored by Git in this working tree. Before changing module dependencies, confirm which module packages are shipped in the GitHub, Freemius, and WordPress.org release artifacts.
+
+## Weak Spots To Turn Into Small Tickets
+
+- WaveSurfer is registered with different versions in admin and frontend code.
+- Tempus Dominus is registered as 6.0.0, while the bundled header identifies `v6.0.0-beta5.1`.
+- `magnific-popup`, `swfobject`, and `swfaddress` appear as module dependency handles but were not found as core-registered handles in this scan.
+- Upload/import UI depends on old `jquery.plupload.queue` and `jqueryFileTree` wrappers.
+- Image editor depends on legacy CamanJS and noUiSlider versions.
+- Module package folders are locally present but ignored by Git, so release artifact ownership needs a separate inventory.
+
+## Verification Checklist For Future Dependency Work
+
+For each dependency upgrade or removal:
+
+1. Confirm bundled version from both WordPress registration and asset header.
+2. Identify all enqueue paths and module dependency declarations.
+3. Create a small GitHub issue for one dependency or one tightly coupled group.
+4. Add a smoke test note to `release-playbook.md` if the dependency affects a recurring release workflow.
+5. Test the exact admin page, frontend module, or media popup that uses the dependency.
+6. Keep Freemius and WordPress.org artifact differences in mind before shipping.

--- a/docs/kb/freemius-and-licensing.md
+++ b/docs/kb/freemius-and-licensing.md
@@ -1,0 +1,160 @@
+# Freemius And Licensing
+
+This document records the current observed license behavior in the local Gmedia Gallery codebase. It is not a customer account record and must not contain license keys, payment data, email addresses, private domains, or customer personal data.
+
+## Current Source Files
+
+- Freemius bootstrap: `grand-media.php`
+- License helpers: `inc/functions.php`
+- License settings UI: `admin/pages/settings/tpl/license.php`
+- Settings processor: `admin/processor/class.processor.settings.php`
+- Module buttons: `admin/pages/modules/functions.php`, `admin/pages/modules/tpl/module-item.php`
+
+## Current Freemius Bootstrap
+
+`grand-media.php` defines `gmg_fs()` immediately after the plugin header and initializes the Freemius SDK from `vendor/freemius/start.php`.
+
+Observed current config:
+
+- Product ID: `20980`
+- Slug: `grand-media`
+- Type: `plugin`
+- Public key is present in code.
+- `is_premium` is currently `false`.
+- `has_premium_version` is currently `false`.
+- `has_addons` is currently `false`.
+- `has_paid_plans` is currently `true`.
+- Menu slug is `GrandMedia`.
+- Contact/support menu entries are disabled in Freemius config.
+- `after_uninstall` is hooked to `gmg_fs_uninstall_cleanup()`.
+
+Important: an old local `FREEMIUS_INTEGRATION_GUIDE.md` note described a different configuration with `is_premium => true` and `has_premium_version => true`. That note was retired because current code is the source of truth.
+
+## License Helper Behavior
+
+`inc/functions.php` centralizes premium access checks:
+
+- `gmedia_has_premium_license()`
+  - Checks Freemius first with `gmg_fs()->can_use_premium_code()`.
+  - Falls back to legacy access when `$gmGallery->options['license_name']` is not empty.
+  - Returns `false` if neither source grants access.
+
+- `gmedia_get_license_type()`
+  - Returns `freemius` when `gmg_fs()->can_use_premium_code()` is true.
+  - Returns `legacy` when no Freemius access is detected and `license_name` is not empty.
+  - Returns `none` otherwise.
+
+Current priority is Freemius first, legacy second, none third.
+
+## Settings UI Behavior
+
+`admin/pages/settings/tpl/license.php` derives:
+
+- `$license_type = gmedia_get_license_type()`
+- `$has_premium = gmedia_has_premium_license()`
+
+Observed behavior:
+
+- If the license type is not `freemius`, the legacy license section is shown.
+- If `license_name` exists, the UI shows "Legacy License Active" and displays the license name as disabled text.
+- If no legacy license exists, the UI shows a legacy activation form and a warning that new licenses are available through Freemius.
+- If no premium access exists, the UI shows an "Unlock Premium Features" / "Get Gmedia Premium" section.
+- Premium feature settings are wrapped in a disabled fieldset when `$has_premium` is false.
+- Purchase links point to `admin.php?page=GrandMedia-pricing`.
+
+## Legacy Activation Behavior
+
+An old local guide said new legacy activations were blocked. Current code does not clearly match that statement.
+
+Observed current code in `admin/processor/class.processor.settings.php`:
+
+- When `license-key-activate` is submitted, the processor checks `gmedia_settings` nonce.
+- If `purchase_key` is present, it posts to `https://codeasily.com/rest/gmedia-key.php`.
+- On a successful response, it sets:
+  - `license_name`
+  - `purchase_key`
+  - `license_key`
+  - `license_key2`
+- On an error response, it clears those license option fields.
+- Settings reset preserves existing license fields.
+
+This needs manual/admin verification before support messaging says legacy activation is blocked or still available.
+
+## Module Access Behavior
+
+Observed current code:
+
+- `admin/pages/modules/functions.php` uses `gmedia_has_premium_license()` when deciding premium button behavior.
+- `admin/pages/modules/tpl/module-item.php` allows free modules, premium-licensed users, or modules with a `buy` link to proceed; otherwise it points users to `GrandMedia-pricing`.
+
+Manual verification is still required for premium modules in the admin UI.
+
+## Support Rules
+
+- Do not ask users to post license keys publicly.
+- Do not copy license keys, account details, payment/order data, emails, or private domains into public GitHub issues.
+- If a license issue needs account inspection, keep it in Gmail/support context and use GitHub only for sanitized product behavior issues.
+- Do not change free/premium behavior until the Freemius and legacy access paths are verified.
+- Any behavior change must be split into a dedicated issue.
+
+## Support Drafts
+
+### Legacy License
+
+```text
+Hi [name],
+
+Gmedia currently supports both Freemius licensing and older legacy license data. Please do not post your license key publicly.
+
+I will check the license behavior carefully against the current version and reply with the safest next step.
+
+Best,
+Serhii
+```
+
+### Freemius Activation
+
+```text
+Hi [name],
+
+New license purchases are handled through Freemius. In the plugin admin, please check the Gmedia Premium/License area and use the Freemius activation or account link there.
+
+Please do not send license keys in a public forum thread. If this needs account-specific help, email support and I will review it there.
+
+Best,
+Serhii
+```
+
+### Lost Key Or Account-Specific Access
+
+```text
+Hi [name],
+
+This looks account-specific, so it should stay out of the public forum. Please contact support by email and include the purchase/account details there, not publicly.
+
+I will check whether this is a Freemius license or an older legacy license and reply with the next step.
+
+Best,
+Serhii
+```
+
+## Verification Matrix
+
+These scenarios must be tested in WordPress admin before closing the licensing review issue:
+
+| Scenario | Expected based on code | Status |
+| --- | --- | --- |
+| No license | `gmedia_get_license_type()` returns `none`; premium fieldset disabled; pricing CTA visible | Not manually verified |
+| Legacy license only | `gmedia_get_license_type()` returns `legacy`; premium feature fieldset enabled | Not manually verified |
+| Freemius license only | `gmedia_get_license_type()` returns `freemius`; Freemius takes priority | Not manually verified |
+| Both legacy and Freemius | `freemius` takes priority; legacy acts as fallback only if Freemius access is unavailable | Not manually verified |
+| Legacy activation form | Current processor appears to still call `codeasily.com/rest/gmedia-key.php`; guide says this may be blocked | Needs verification |
+| Module buttons | Premium access should be controlled by `gmedia_has_premium_license()` | Not manually verified |
+| Settings reset | Existing legacy license fields should be preserved | Not manually verified |
+
+## Open Risks
+
+- Retired local notes and current code disagreed on whether new legacy activations are blocked.
+- Retired local notes described a Freemius config that differed from the current `grand-media.php` config.
+- `gmedia_has_premium_license()` uses `can_use_premium_code()`; verify this is the intended Freemius method for the current wp.org/free plugin flow.
+- Premium/free boundary audit is intentionally deferred until these license paths are verified.

--- a/docs/kb/release-playbook.md
+++ b/docs/kb/release-playbook.md
@@ -1,0 +1,232 @@
+# Release Playbook
+
+Gmedia Gallery releases should be small, issue-linked, and verified before publishing.
+
+## Cadence
+
+- Normal cadence: maximum two plugin updates per week.
+- Exceptions: confirmed security issue, fatal error on supported WordPress/PHP, data loss, or upload-blocking regression.
+
+## Release Channel
+
+1. Prepare and verify changes in GitHub.
+2. Send the release/build through Freemius.
+3. Download the Freemius-processed archive.
+4. Publish the special WordPress.org version from that processed archive to SVN.
+
+Do not publish a raw GitHub archive to WordPress.org SVN unless the release process is explicitly changed.
+
+## Compatibility Baseline
+
+- Target real support baseline: WordPress 6.0+ and PHP 7.4+.
+- Current public headers/readme may still declare older minimums until a dedicated compatibility issue updates them.
+- Do not update `Requires at least`, `Requires PHP`, or `Tested up to` by guesswork.
+
+## Pre-Release Checklist
+
+- GitHub issues are linked to the release changes.
+- PHP syntax lint passes from the plugin root:
+
+```bash
+find . -type f -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+```
+
+- Local admin smoke tests pass.
+- Frontend smoke tests pass for at least one existing shortcode and one Gmedia block when available.
+- Upload/import smoke tests pass if upload, import, media, dependencies, or admin JavaScript were touched.
+- Module smoke tests pass for every touched module.
+- Freemius/license checks pass if licensing, modules, update flow, or premium access were touched.
+- `readme.txt` changelog is updated.
+- `changelog.txt` is updated if used for the release.
+- WordPress.org metadata is checked against the actual release artifact.
+
+## Baseline Local Verification
+
+Use this checklist for maintenance slices before a release candidate exists. If a slice does not touch a surface, record it as "not touched" rather than testing unrelated flows.
+
+### Environment
+
+- Local site: `https://wp-dev.loc/`.
+- Plugin admin page: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia`.
+- Plugin root: `/Users/simka/_LOCAL_/wp-dev/app/public/wp-content/plugins/grand-media`.
+- Confirm PHP syntax:
+
+```bash
+find . -type f -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+```
+
+- Record local versions:
+
+```bash
+php -v
+```
+
+- WP-CLI is currently a tooling gap. If `wp` is not available, record that and use the WordPress admin UI for activation and smoke checks:
+
+```bash
+wp core version
+```
+
+Expected if the gap still exists:
+
+```text
+zsh:1: command not found: wp
+```
+
+### Activation
+
+Use one of these paths:
+
+- Preferred once WP-CLI is available:
+
+```bash
+wp plugin activate grand-media
+```
+
+- Current fallback: activate Gmedia Gallery in WordPress admin under Plugins.
+
+Pass criteria:
+
+- Plugin activates without a fatal error.
+- WordPress admin remains reachable.
+- Gmedia menu appears in the admin sidebar.
+
+### Admin Pages
+
+Open each page and check for fatal errors, blank pages, obvious PHP warnings, and browser console errors.
+
+- Library: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia`
+- Add/Import Files: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia_AddMedia`
+- Tags: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia_Tags`
+- Categories: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia_Categories`
+- Albums: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia_Albums`
+- Galleries: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia_Galleries`
+- Modules: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia_Modules`
+- Settings: `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia_Settings`
+
+Pass criteria:
+
+- Page loads inside WordPress admin.
+- Existing media/gallery/module data is visible where expected.
+- No critical console errors block interaction.
+- No visible PHP warnings/notices are shown in the admin UI.
+
+### Upload And Import
+
+Run this when upload, import, admin JavaScript, media handling, dependencies, or permissions are touched.
+
+1. Open Add/Import Files.
+2. Select a small JPG file.
+3. Confirm the upload controls become usable.
+4. Start upload.
+5. Confirm the file appears in Gmedia Library.
+6. If terms were touched, assign an album/category/tag during upload and verify it persists.
+
+Pass criteria:
+
+- Upload starts.
+- Upload completes without JavaScript/network errors.
+- New item appears in the Library.
+- Assigned terms persist after page reload.
+
+### Galleries
+
+Run this when gallery query, module settings, shortcode/block insertion, or frontend output is touched.
+
+1. Open Galleries.
+2. Open or create a test gallery.
+3. Confirm module selection/settings load.
+4. Save without changing premium/free behavior.
+5. View a page/post containing the gallery shortcode or block.
+
+Pass criteria:
+
+- Gallery settings load and save.
+- Frontend gallery renders.
+- Images open or navigate according to the selected module behavior.
+- No unrelated module settings are reset.
+
+### Frontend Shortcode
+
+Use an existing gallery shortcode if available.
+
+Pass criteria:
+
+- The shortcode renders a gallery on the frontend.
+- Public users can view public galleries.
+- Draft/private galleries remain restricted according to current behavior.
+- Browser console does not show blocking JavaScript errors.
+
+### Block Editor
+
+Run this when block assets, admin assets, shortcode insertion, or editor integration is touched.
+
+1. Open a test post/page in the block editor.
+2. Insert each available Gmedia block when practical:
+   - Gmedia Gallery
+   - Gmedia Album
+   - Gmedia Category
+   - Gmedia Tag
+3. Save/update the post.
+4. View the frontend.
+
+Pass criteria:
+
+- Blocks are available in the editor.
+- Editor does not crash.
+- Saved content renders on the frontend.
+
+### Modules
+
+Run this when a module, shared module option, or shared frontend dependency is touched.
+
+Pass criteria:
+
+- Touched module preview loads.
+- A gallery using the touched module renders on frontend.
+- Module-specific controls still work.
+- If a premium module is involved, license behavior is unchanged unless the issue explicitly changes it.
+
+### Licensing
+
+Run this when Freemius, legacy license logic, module install/update behavior, premium buttons, or settings license UI are touched.
+
+Check scenarios:
+
+- No license.
+- Legacy license option present.
+- Freemius license active.
+- Both legacy and Freemius license data present.
+
+Pass criteria:
+
+- `gmedia_has_premium_license()` result matches intended access.
+- `gmedia_get_license_type()` returns the expected source.
+- Premium buttons and notices match access state.
+- Existing legacy access is not broken unintentionally.
+
+### Cleanup
+
+After local verification:
+
+- Record exact checks performed in the issue or PR.
+- Record skipped checks with a reason.
+- Record local WordPress/PHP/plugin versions.
+- Record any console/network errors, even if they are not part of the current slice.
+
+## Local Tooling Notes
+
+- PHP CLI was verified locally as PHP 8.4.3 on 2026-06-05.
+- `wp` CLI was not found in PATH on 2026-06-05.
+- If WP-CLI becomes part of release verification, first document the Local by WP Engine-compatible invocation.
+
+## Rollback Notes
+
+For every release, keep:
+
+- Git commit SHA.
+- Freemius processed archive reference.
+- WordPress.org SVN revision.
+- List of issues included.
+- Manual smoke tests performed.
+- Known risks and rollback trigger.

--- a/docs/kb/support-playbook.md
+++ b/docs/kb/support-playbook.md
@@ -1,0 +1,286 @@
+# Support Playbook
+
+This playbook covers Gmail and WordPress.org forum support for Gmedia Gallery.
+
+## Policy
+
+- Current support policy: best effort, no public SLA promise yet.
+- Default mode for email replies: draft-only.
+- Do not send, archive, delete, move, or label emails unless explicitly asked.
+- Turn repeated questions into documentation and small GitHub issues.
+
+## Gmail Scope
+
+- Support inbox: `gmediafolder@gmail.com`.
+- Primary scope: Gmail label `Gmedia Support`.
+- Secondary context: `SENT` mail for previous support replies and tone/history.
+- Do not scan unlabeled `INBOX` unless explicitly asked or when setting up/repairing the support label workflow.
+
+## WordPress.org Forum Scope
+
+- Forum: `https://wordpress.org/support/plugin/grand-media/`.
+- Check opportunistically and after releases until a formal cadence is chosen.
+- Prioritize:
+  - Security or data loss.
+  - Fatal errors.
+  - Upload broken.
+  - Galleries not displaying.
+  - Paid-license confusion posted publicly.
+  - Repeated how-to questions.
+
+## Triage Categories
+
+- `bug`: reproducible behavior defect.
+- `security`: possible vulnerability or unsafe behavior.
+- `licensing`: Freemius, legacy license, lost key, activation, premium access.
+- `support`: answer-only or support-process task.
+- `docs`: repeated question or missing article.
+- `compatibility`: WordPress, PHP, browser, theme, or plugin compatibility.
+- `wordpress-org`: forum, readme, SVN, or plugin directory issue.
+- `freemius`: Freemius processing, checkout, account, updates, SDK, or premium archive flow.
+- `module`: skin/module-specific issue.
+- `frontend`: shortcode, block, template, public AJAX, or gallery display.
+- `admin`: admin UI, upload, import, settings, modules, processors.
+
+## Reply Workflow
+
+1. Read the latest customer/forum message.
+2. Identify plugin version, WordPress version, PHP version, module name, and affected page if provided.
+3. Search current repo docs and issues.
+4. Reproduce locally when practical.
+5. If it is a bug, create or link a small GitHub issue.
+6. Draft a concise reply with exact assumptions and next step.
+7. If the question repeats, create or update a docs issue.
+
+## Draft Or Issue Decision
+
+Use a draft-only reply when:
+
+- The question is a one-off how-to.
+- The answer is already documented or can be answered from current plugin behavior.
+- The customer needs a simple clarification and no code/docs change is needed.
+- The request is account-specific and should stay out of public GitHub issues.
+
+Create or link a GitHub issue when:
+
+- A bug can be reproduced or has enough evidence to investigate.
+- More than one user reports the same symptom.
+- A support answer needs a docs article.
+- A licensing/Freemius behavior needs verification.
+- A compatibility report needs local testing.
+- A release/readme/SVN/Freemius process gap is discovered.
+
+Create a docs issue when:
+
+- A question repeats.
+- A reply requires more than a short answer.
+- The user is confused by free vs premium boundaries.
+- The setup path is unclear.
+- A support answer would be useful on codeasily.com.
+
+Do not create a public issue yet when:
+
+- The report contains sensitive customer data that cannot be sanitized quickly.
+- The topic is a possible security flaw and public details could increase risk before validation.
+- The issue depends on a private license/payment/account record.
+- The next step requires authorization, account access, or an exact external name that is not available.
+
+## Privacy Rules
+
+Do not put these into public GitHub issues or public forum replies:
+
+- License keys.
+- Customer personal data.
+- Private domains unless the customer already posted them publicly and they are necessary.
+- Email addresses beyond public usernames.
+- Payment/order details.
+- Exploit payloads or step-by-step security abuse instructions.
+- Sensitive operational details.
+
+## Draft Reply Shape
+
+Use this compact structure:
+
+```text
+Hi [name],
+
+Thanks for the details. Based on [versions/symptom], this looks like [short diagnosis or next check].
+
+[One or two concrete steps, or what we are checking/fixing.]
+
+If you can, please confirm [only missing facts needed].
+
+Best,
+Serhii
+```
+
+## Draft Templates
+
+### Bug Or Repro Request
+
+```text
+Hi [name],
+
+Thanks for the report. I need to reproduce this before changing the plugin behavior.
+
+Please send:
+- Gmedia Gallery version
+- WordPress version
+- PHP version
+- The gallery/module name if this happens only with one gallery
+- A screenshot or exact error text if available
+
+I will check it against the current version and create a small bug ticket if I can reproduce it.
+
+Best,
+Serhii
+```
+
+### Confirmed Bug
+
+```text
+Hi [name],
+
+Thanks for the details. I was able to reproduce this in the current version.
+
+I created a small issue for the fix and will keep the change scoped to this behavior so it does not affect unrelated galleries/modules.
+
+For now, the safest workaround is [workaround if confirmed].
+
+Best,
+Serhii
+```
+
+### Licensing Or Freemius
+
+```text
+Hi [name],
+
+Thanks for reaching out. License/account issues need to be checked carefully because Gmedia supports both Freemius licenses and older legacy licenses.
+
+Please do not post your license key publicly. If you already sent account details by email, I will check the license state there and reply with the next step.
+
+Best,
+Serhii
+```
+
+### How-To
+
+```text
+Hi [name],
+
+You can do this from Gmedia Gallery by:
+
+1. Go to [admin page].
+2. Choose [album/gallery/module/action].
+3. Save the changes.
+4. Insert or update the gallery on the page/post.
+
+If you tell me which module/gallery you are using, I can point to the exact setting.
+
+Best,
+Serhii
+```
+
+### Compatibility
+
+```text
+Hi [name],
+
+This may be a compatibility issue, so I need the environment details before guessing.
+
+Please confirm:
+- WordPress version
+- PHP version
+- Gmedia Gallery version
+- Theme name
+- Whether this happens with other plugins temporarily disabled
+- Browser console error, if there is one
+
+I will compare that with the supported baseline and current known issues.
+
+Best,
+Serhii
+```
+
+### Docs Gap
+
+```text
+Hi [name],
+
+Thanks, this question shows that the current documentation is not clear enough.
+
+The short answer is: [answer].
+
+I will also add this to the documentation so future users can find it without waiting for support.
+
+Best,
+Serhii
+```
+
+### Security Report
+
+```text
+Hi [name],
+
+Thanks for reporting this. Please do not post exploit details publicly.
+
+I will validate the report against the current plugin version first. If it is confirmed, I will handle it as a security fix and avoid sharing sensitive details in public issues or forum replies.
+
+Best,
+Serhii
+```
+
+## Public Issue Template
+
+Use this shape after sanitizing details:
+
+```markdown
+## User Problem
+
+[Short public-safe symptom.]
+
+## Affected Surface
+
+[admin/frontend/module/licensing/docs/compatibility]
+
+## Evidence
+
+- Plugin version:
+- WordPress version:
+- PHP version:
+- Module/gallery if relevant:
+
+## Expected Behavior
+
+[What should happen.]
+
+## Actual Behavior
+
+[What happens, without private data.]
+
+## Verification
+
+- [ ] Reproduce locally
+- [ ] Identify affected code path
+- [ ] Add/update docs or tests if needed
+- [ ] Verify fix/manual flow
+
+## Privacy Check
+
+- [ ] No license keys
+- [ ] No customer personal data
+- [ ] No private domains unless necessary and already public
+- [ ] No payment/order details
+- [ ] No exploit payloads
+```
+
+## Closing The Loop
+
+After a support item is handled:
+
+- If draft-only, keep the draft concise and wait for explicit send approval.
+- If an issue was created, link it in the internal support note or draft reply only when appropriate.
+- If a docs gap was found, create or update the docs issue.
+- If a workaround was given, record whether it is temporary or recommended.
+- If the answer depends on a future release, add it to release notes when the fix ships.

--- a/docs/kb/upload-flow-repro.md
+++ b/docs/kb/upload-flow-repro.md
@@ -1,0 +1,59 @@
+# Upload Flow Reproduction Notes
+
+Last checked: 2026-06-05
+
+This page records local upload-flow reproduction checks for support reports about inactive upload buttons or failed uploads.
+
+## 2026-06-05: Add/Import Files
+
+GitHub issue: #9, "Reproduce upload flow reports on current local environment"
+
+### Environment
+
+| Item | Value |
+| --- | --- |
+| Local URL | `https://wp-dev.loc/wp-admin/admin.php?page=GrandMedia_AddMedia` |
+| WordPress | 7.0 |
+| Gmedia Gallery | 1.25.0 |
+| PHP CLI | 8.4.3 |
+| Upload UI | `jquery.plupload.queue` 2.3.9, WordPress core Plupload 2.1.9 |
+
+### Steps
+
+1. Open `Gmedia -> Add/Import Files`.
+2. Confirm upload UI renders with `Add Files`, `Start Upload`, and the drag/drop area.
+3. Select a valid PNG file from disk.
+4. Confirm the selected file appears in the queue.
+5. Confirm `Start Upload` no longer has the `plupload_disabled` class.
+6. Click `Start Upload`.
+7. Confirm final row class, footer text, console output, and generated files on disk.
+
+### Result
+
+Status: not reproduced for the reported inactive `Start Upload` behavior.
+
+Evidence:
+
+- Empty queue: `Start Upload` has class `plupload_button plupload_start plupload_disabled`, which is expected.
+- After selecting `/private/tmp/gmedia-upload-test-64.png`, the file row appears as `plupload_delete`, and `Start Upload` changes to `plupload_button plupload_start`.
+- After clicking `Start Upload`, the file row changes to `plupload_done`.
+- Footer text becomes `Uploaded 1/1 files 100% 313 b`.
+- Files are created:
+  - `wp-content/grand-media/image/original/gmedia-upload-test-64.png`
+  - `wp-content/grand-media/image/thumb/gmedia-upload-test-64.png`
+  - `wp-content/grand-media/image/gmedia-upload-test-64.png`
+- Browser console showed jQuery Migrate warnings only:
+  - `jQuery.trim is deprecated; use String.prototype.trim`
+  - `jQuery.fn.click() event shorthand is deprecated`
+  - `jQuery.parseJSON is deprecated; use JSON.parse`
+
+### Notes
+
+- A tiny 1x1 PNG test file queued correctly and enabled `Start Upload`, but finished as `plupload_failed` while the footer still said `Uploaded 1/1 files 100% 69 b`. No file was created on disk for that tiny file. This was not treated as the main repro because a normal 64x64 PNG uploaded successfully.
+- Current local `debug.log` shows WordPress 7.0 deprecation output for `addslashes_gpc()` in Gmedia code paths. This is separate from the upload-button report, but should become a compatibility issue because debug output can break JSON/header flows in some contexts.
+
+### Follow-Up Candidates
+
+- #10: Replace deprecated `addslashes_gpc()` usage for WordPress 7.0 compatibility.
+- If users continue reporting disabled upload buttons, collect their browser console, WordPress version, PHP version, selected file type/size, and whether the file appears in the queue before `Start Upload`.
+- If users report "Uploaded 1/1" but no file appears, reproduce with the exact file and inspect the upload AJAX response.

--- a/inc/db.connect.php
+++ b/inc/db.connect.php
@@ -90,7 +90,7 @@ class GmediaDB {
 			$searchand = '';
 
 			foreach ( (array) $search_terms as $term ) {
-				$term = addslashes_gpc( $term );
+				$term = wp_slash( $term );
 
 				$search .= "{$searchand}(($wpdb->posts.post_title LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_content LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_name LIKE '{$n}{$term}{$n}'))";
 
@@ -239,7 +239,7 @@ class GmediaDB {
 			$searchand = '';
 
 			foreach ( (array) $search_terms as $term ) {
-				$term = addslashes_gpc( $term );
+				$term = wp_slash( $term );
 
 				$search .= "{$searchand}(($wpdb->posts.post_title LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_content LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_name LIKE '{$n}{$term}{$n}'))";
 
@@ -2100,7 +2100,7 @@ class GmediaDB {
 
 		// Author/user stuff for ID.
 		if ( ! empty( $q['author'] ) && '0' !== $q['author'] ) {
-			$q['author'] = addslashes_gpc( '' . urldecode( $q['author'] ) );
+			$q['author'] = wp_slash( '' . urldecode( $q['author'] ) );
 			$authors     = array_unique( array_map( 'intval', preg_split( '/[,\s]+/', $q['author'] ) ) );
 			foreach ( $authors as $author ) {
 				$key         = $author > 0 ? 'author__in' : 'author__not_in';
@@ -2161,7 +2161,7 @@ class GmediaDB {
 				$allowed_keys[] = 'custom';
 			}
 			$q['orderby'] = urldecode( $q['orderby'] );
-			$q['orderby'] = addslashes_gpc( $q['orderby'] );
+			$q['orderby'] = wp_slash( $q['orderby'] );
 			if ( in_array( $q['orderby'], array( '_created_timestamp', 'views', 'likes', '_size' ), true ) ) {
 				$q['meta_key'] = $q['orderby'];
 				$q['orderby']  = 'meta_value_num';
@@ -2382,7 +2382,7 @@ class GmediaDB {
 		if ( isset( $q['cat'] ) ) {
 			if ( ! empty( $q['cat'] ) && ( '0' !== $q['cat'] ) && ( 0 !== $q['cat'] ) ) {
 				$q['cat']  = '' . urldecode( $q['cat'] ) . '';
-				$q['cat']  = addslashes_gpc( $q['cat'] );
+				$q['cat']  = wp_slash( $q['cat'] );
 				$cat_array = preg_split( '/[,\s]+/', $q['cat'] );
 				$q['cat']  = '';
 				$req_cats  = array();
@@ -2856,7 +2856,7 @@ class GmediaDB {
 		if ( isset( $q['alb'] ) ) {
 			if ( ! empty( $q['alb'] ) && ( '0' !== $q['alb'] ) && ( 0 !== $q['alb'] ) ) {
 				$q['alb']  = '' . urldecode( $q['alb'] ) . '';
-				$q['alb']  = addslashes_gpc( $q['alb'] );
+				$q['alb']  = wp_slash( $q['alb'] );
 				$alb_array = preg_split( '/[,\s]+/', $q['alb'] );
 				$q['alb']  = '';
 				$req_albs  = array();

--- a/tests/compat/no-addslashes-gpc.php
+++ b/tests/compat/no-addslashes-gpc.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Ensure deprecated addslashes_gpc() is not used in plugin code.
+ */
+
+$root = dirname( __DIR__, 2 );
+$rii  = new RecursiveIteratorIterator(
+	new RecursiveDirectoryIterator(
+		$root,
+		FilesystemIterator::SKIP_DOTS
+	)
+);
+
+$matches = array();
+
+foreach ( $rii as $file ) {
+	if ( ! $file->isFile() || 'php' !== $file->getExtension() ) {
+		continue;
+	}
+
+	$path     = $file->getPathname();
+	$relative = substr( $path, strlen( $root ) + 1 );
+
+	if ( 0 === strpos( $relative, 'vendor/' ) || 0 === strpos( $relative, 'tests/' ) ) {
+		continue;
+	}
+
+	$contents = file_get_contents( $path );
+	if ( false !== strpos( $contents, 'addslashes_gpc(' ) ) {
+		$matches[] = $relative;
+	}
+}
+
+if ( $matches ) {
+	fwrite( STDERR, "Deprecated addslashes_gpc() usage found:\n- " . implode( "\n- ", $matches ) . "\n" );
+	exit( 1 );
+}
+
+echo "No addslashes_gpc() usage found.\n";


### PR DESCRIPTION
## Summary
- Add repo-native `docs/kb` maintenance documentation for architecture, releases, support triage, licensing, dependency inventory, and upload-flow repro notes.
- Ignore local Graphify output with `/graphify-out/`.
- Replace deprecated `addslashes_gpc()` calls with `wp_slash()` and add a small compatibility guard test.

## Why
This establishes the repo as the source of truth for Gmedia Gallery maintenance docs and captures the first local compatibility/repro findings. The WordPress 7.0 smoke checks showed `addslashes_gpc()` deprecation output, so this PR removes that deprecated wrapper before it can interfere with debug/header/JSON flows.

## Validation
- `php tests/compat/no-addslashes-gpc.php`
- `find . -type f -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `git diff --check --cached`
- Browser smoke on local WordPress 7.0: Gmedia Library, Gmedia Logs, and Add/Import Files load without page notices.

## Related Issues
- #4
- #6
- #7
- #8
- #9
- #10