### PR TITLE
Harden SQL LIKE escaping in Gmedia search queries

### DIFF
--- a/admin/logs.php
+++ b/admin/logs.php
@@ -60,18 +60,17 @@ if ( isset( $_GET['s'] ) ) {
 			$matches[0]
 		);
 
-		$n         = '%';
 		$searchand = '';
 
 		foreach ( (array) $search_terms as $search_term ) {
-			$search_term = wp_slash( $search_term );
-			$log_search  .= "{$searchand}(g.title LIKE '{$n}{$search_term}{$n}') OR (g.description LIKE '{$n}{$search_term}{$n}')";
+			$search_like = '%' . $wpdb->esc_like( $search_term ) . '%';
+			$log_search  .= $wpdb->prepare( "{$searchand}((g.title LIKE %s) OR (g.description LIKE %s))", $search_like, $search_like );
 			$searchand   = ' AND ';
 		}
 
-		$search_term = esc_sql( $log_s );
 		if ( count( $search_terms ) > 1 && $search_terms[0] !== $log_s ) {
-			$log_search .= " OR (g.title LIKE '{$n}{$search_term}{$n}') OR (g.description LIKE '{$n}{$search_term}{$n}')";
+			$search_like = '%' . $wpdb->esc_like( $log_s ) . '%';
+			$log_search  .= $wpdb->prepare( ' OR ((g.title LIKE %s) OR (g.description LIKE %s))', $search_like, $search_like );
 		}
 
 		if ( ! empty( $log_search ) ) {

--- a/inc/db.connect.php
+++ b/inc/db.connect.php
@@ -86,20 +86,19 @@ class GmediaDB {
 				$matches[0]
 			);
 
-			$n         = '%';
 			$searchand = '';
 
 			foreach ( (array) $search_terms as $term ) {
-				$term = wp_slash( $term );
+				$search_like = '%' . $wpdb->esc_like( $term ) . '%';
 
-				$search .= "{$searchand}(($wpdb->posts.post_title LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_content LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_name LIKE '{$n}{$term}{$n}'))";
+				$search .= $wpdb->prepare( "{$searchand}(($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_name LIKE %s))", $search_like, $search_like, $search_like );
 
 				$searchand = ' AND ';
 			}
 
-			$term = esc_sql( $s );
 			if ( count( $search_terms ) > 1 && $search_terms[0] !== $s ) {
-				$search .= " OR ($wpdb->posts.post_title LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_content LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_name LIKE '{$n}{$term}{$n}')";
+				$search_like = '%' . $wpdb->esc_like( $s ) . '%';
+				$search      .= $wpdb->prepare( " OR ($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_name LIKE %s)", $search_like, $search_like, $search_like );
 			}
 
 			if ( ! empty( $search ) ) {
@@ -235,20 +234,19 @@ class GmediaDB {
 				$matches[0]
 			);
 
-			$n         = '%';
 			$searchand = '';
 
 			foreach ( (array) $search_terms as $term ) {
-				$term = wp_slash( $term );
+				$search_like = '%' . $wpdb->esc_like( $term ) . '%';
 
-				$search .= "{$searchand}(($wpdb->posts.post_title LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_content LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_name LIKE '{$n}{$term}{$n}'))";
+				$search .= $wpdb->prepare( "{$searchand}(($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_name LIKE %s))", $search_like, $search_like, $search_like );
 
 				$searchand = ' AND ';
 			}
 
-			$term = esc_sql( $s );
 			if ( count( $search_terms ) > 1 && $search_terms[0] !== $s ) {
-				$search .= " OR ($wpdb->posts.post_title LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_content LIKE '{$n}{$term}{$n}') OR ($wpdb->posts.post_name LIKE '{$n}{$term}{$n}')";
+				$search_like = '%' . $wpdb->esc_like( $s ) . '%';
+				$search      .= $wpdb->prepare( " OR ($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_name LIKE %s)", $search_like, $search_like, $search_like );
 			}
 
 			if ( ! empty( $search ) ) {
@@ -1730,12 +1728,11 @@ class GmediaDB {
 			} else {
 				$q['search_terms'] = $q['s'];
 			}
-			$n         = '%';
 			$searchand = '';
 			foreach ( (array) $q['search_terms'] as $term ) {
-				$term = esc_sql( addcslashes( $term, '_%\\' ) );
+				$search_like = '%' . $wpdb->esc_like( $term ) . '%';
 
-				$search .= "{$searchand}(({$wpdb->prefix}gmedia.title LIKE '{$n}{$term}{$n}') OR ({$wpdb->prefix}gmedia.description LIKE '{$n}{$term}{$n}') OR ({$wpdb->prefix}gmedia.gmuid LIKE '{$n}{$term}{$n}'))";
+				$search .= $wpdb->prepare( "{$searchand}(({$wpdb->prefix}gmedia.title LIKE %s) OR ({$wpdb->prefix}gmedia.description LIKE %s) OR ({$wpdb->prefix}gmedia.gmuid LIKE %s))", $search_like, $search_like, $search_like );
 
 				$searchand = ' AND ';
 			}

--- a/tests/compat/sql-like-escaping.php
+++ b/tests/compat/sql-like-escaping.php
@@ -1,0 +1,81 @@
+<?php
+
+$root = dirname( __DIR__, 2 );
+
+$checks = array(
+	'admin/logs.php'     => array(
+		'forbidden_regex' => array(
+			'/\$search_term\s*=\s*wp_slash\s*\(/',
+		),
+		'forbidden_text'  => array(
+			"LIKE '{\$n}{\$search_term}{\$n}'",
+		),
+		'required'        => array(
+			'/\$wpdb->esc_like\s*\(\s*\$search_term\s*\)/',
+			'/\$wpdb->prepare\s*\(/',
+		),
+		'required_text'   => array(
+			'{$searchand}((g.title LIKE %s) OR (g.description LIKE %s))',
+		),
+	),
+	'inc/db.connect.php' => array(
+		'forbidden_regex' => array(
+			'/\$term\s*=\s*wp_slash\s*\(/',
+			'/esc_sql\s*\(\s*addcslashes\s*\(/',
+		),
+		'forbidden_text'  => array(
+			"LIKE '{\$n}{\$term}{\$n}'",
+		),
+		'required'        => array(
+			'/\$wpdb->esc_like\s*\(\s*\$term\s*\)/',
+			'/\$wpdb->prepare\s*\(/',
+		),
+		'required_text'   => array(
+			'{$searchand}(($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_name LIKE %s))',
+			'{$searchand}(({$wpdb->prefix}gmedia.title LIKE %s) OR ({$wpdb->prefix}gmedia.description LIKE %s) OR ({$wpdb->prefix}gmedia.gmuid LIKE %s))',
+		),
+	),
+);
+
+$failures = array();
+
+foreach ( $checks as $relative_path => $rules ) {
+	$path = $root . '/' . $relative_path;
+	$code = file_get_contents( $path );
+
+	if ( false === $code ) {
+		$failures[] = "Could not read {$relative_path}";
+		continue;
+	}
+
+	foreach ( $rules['forbidden_regex'] as $pattern ) {
+		if ( preg_match( $pattern, $code ) ) {
+			$failures[] = "{$relative_path} still matches forbidden pattern {$pattern}";
+		}
+	}
+
+	foreach ( $rules['forbidden_text'] as $text ) {
+		if ( false !== strpos( $code, $text ) ) {
+			$failures[] = "{$relative_path} still contains forbidden text {$text}";
+		}
+	}
+
+	foreach ( $rules['required'] as $pattern ) {
+		if ( ! preg_match( $pattern, $code ) ) {
+			$failures[] = "{$relative_path} does not match required pattern {$pattern}";
+		}
+	}
+
+	foreach ( $rules['required_text'] as $text ) {
+		if ( false === strpos( $code, $text ) ) {
+			$failures[] = "{$relative_path} does not contain required text {$text}";
+		}
+	}
+}
+
+if ( $failures ) {
+	echo implode( PHP_EOL, $failures ) . PHP_EOL;
+	exit( 1 );
+}
+
+echo 'SQL LIKE search escaping guard passed.' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Replace direct SQL LIKE search interpolation with WordPress wpdb esc_like plus prepare in Gmedia admin/search query builders.
- Cover the Devin-highlighted admin/WP media search paths and the matching Gmedia library search path.
- Add a compatibility guard for this escaping pattern.

## Test Plan
- php tests/compat/sql-like-escaping.php
- php tests/compat/no-addslashes-gpc.php
- full PHP syntax lint outside vendor
- git diff --check
- Browser smoke: GrandMedia_Logs, GrandMedia_WordpressLibrary, and GrandMedia with percent/underscore/quote search input loaded without fatal errors, admin notices, or console errors.

Closes #12
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pasyuk/grand-media/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->