### PR TITLE
Harden admin AJAX nonce and capability checks

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -195,7 +195,7 @@ class GmediaAdmin {
 
 		// check for upgrade.
 		if ( get_option( 'gmediaDbVersion' ) !== GMEDIA_DBVERSION ) {
-			if ( get_transient( 'gmediaUpgrade' ) || ( 'gmedia' === $gmCore->_get( 'do_update' ) ) ) {
+			if ( current_user_can( 'manage_options' ) && ( get_transient( 'gmediaUpgrade' ) || ( 'gmedia' === $gmCore->_get( 'do_update' ) ) ) ) {
 				$sideLinks['grandTitle'] = __( 'Updating GmediaGallery Plugin', 'grand-media' );
 				$sideLinks['sideLinks']  = '';
 				$gmProcessor->page       = 'GrandMedia_Update';

--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -2261,6 +2261,11 @@ function gmedia_term_sortorder() {
 add_action( 'wp_ajax_gmedia_upgrade_process', 'gmedia_upgrade_process' );
 function gmedia_upgrade_process() {
 
+	check_ajax_referer( 'gmedia_ajax_long_operations', '_wpnonce_ajax_long_operations' );
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( array( 'message' => esc_html__( 'You are not allowed to run this process.', 'grand-media' ) ), 403 );
+	}
+
 	$db_version = get_option( 'gmediaDbVersion' );
 	$info       = get_transient( 'gmediaHeavyJob' );
 	$result     = array( 'content' => '' );

--- a/config/update.php
+++ b/config/update.php
@@ -5,6 +5,7 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  * Update Gmedia plugin
  */
 function gmedia_upgrade_required_admin_notice() {
+	$can_update = current_user_can( 'manage_options' );
 	?>
 	<div id="message" class="updated gmedia-message">
 		<p><?php esc_html_e( '<strong>GmediaGallery Database Update Required</strong> &#8211; We need to update your install to the latest version.', 'grand-media' ); ?></p>
@@ -13,15 +14,19 @@ function gmedia_upgrade_required_admin_notice() {
 
 		<p><?php esc_html_e( 'The update process may take a little while, so please be patient.', 'grand-media' ); ?></p>
 
-		<p class="submit">
-			<a href="<?php echo esc_url( add_query_arg( 'do_update', 'gmedia', admin_url( 'admin.php?page=GrandMedia' ) ) ); ?>" class="gm-update-now button-primary"><?php esc_html_e( 'Run the updater', 'grand-media' ); ?></a>
-		</p>
+		<?php if ( $can_update ) { ?>
+			<p class="submit">
+				<a href="<?php echo esc_url( add_query_arg( 'do_update', 'gmedia', admin_url( 'admin.php?page=GrandMedia' ) ) ); ?>" class="gm-update-now button-primary"><?php esc_html_e( 'Run the updater', 'grand-media' ); ?></a>
+			</p>
+		<?php } ?>
 	</div>
-	<script type="text/javascript">
-			jQuery('.gm-update-now').click('click', function() {
-				return confirm('<?php echo esc_js( esc_html__( 'It is strongly recommended that you backup your database before proceeding. Are you sure you wish to run the updater now?', 'grand-media' ) ); ?>');
-			});
-	</script>
+	<?php if ( $can_update ) { ?>
+		<script type="text/javascript">
+				jQuery('.gm-update-now').click('click', function() {
+					return confirm('<?php echo esc_js( esc_html__( 'It is strongly recommended that you backup your database before proceeding. Are you sure you wish to run the updater now?', 'grand-media' ) ); ?>');
+				});
+		</script>
+	<?php } ?>
 	<?php
 
 }
@@ -38,6 +43,7 @@ function gmedia_upgrade_process_admin_notice() {
 
 function gmedia_upgrade_progress_panel() {
 	gmedia_do_update();
+	$nonce = wp_create_nonce( 'gmedia_ajax_long_operations' );
 	?>
 	<div id="gmediaUpdate" class="card m-0 mw-100 p-0">
 		<div class="card-body">
@@ -56,7 +62,7 @@ function gmedia_upgrade_progress_panel() {
 							type: 'get',
 							dataType: 'json',
 							url: ajaxurl,
-							data: {action: 'gmedia_upgrade_process'},
+							data: {action: 'gmedia_upgrade_process', _wpnonce_ajax_long_operations: '<?php echo esc_js( $nonce ); ?>'},
 						}).done(function(data) {
 							if (data.content) {
 								jQuery('#gmUpdateProgress').html(data.content);

--- a/tests/compat/admin-ajax-nonce-guards.php
+++ b/tests/compat/admin-ajax-nonce-guards.php
@@ -1,0 +1,56 @@
+<?php
+
+$root = dirname( __DIR__, 2 );
+
+$ajax_code   = file_get_contents( $root . '/admin/ajax.php' );
+$update_code = file_get_contents( $root . '/config/update.php' );
+$admin_code  = file_get_contents( $root . '/admin/admin.php' );
+
+$failures = array();
+
+if ( false === $ajax_code ) {
+	$failures[] = 'Could not read admin/ajax.php';
+}
+
+if ( false === $update_code ) {
+	$failures[] = 'Could not read config/update.php';
+}
+
+if ( false === $admin_code ) {
+	$failures[] = 'Could not read admin/admin.php';
+}
+
+if ( ! $failures ) {
+	if ( ! preg_match( '/function\s+gmedia_upgrade_process\s*\(\s*\)\s*\{(?P<body>.*?)^\}/ms', $ajax_code, $matches ) ) {
+		$failures[] = 'Could not find gmedia_upgrade_process() body';
+	} else {
+		$body = $matches['body'];
+
+		if ( false === strpos( $body, "check_ajax_referer( 'gmedia_ajax_long_operations', '_wpnonce_ajax_long_operations' )" ) ) {
+			$failures[] = 'gmedia_upgrade_process() must validate the long-operation nonce';
+		}
+
+		if ( false === strpos( $body, "current_user_can( 'manage_options' )" ) ) {
+			$failures[] = 'gmedia_upgrade_process() must require manage_options capability';
+		}
+	}
+
+	if ( false === strpos( $update_code, "_wpnonce_ajax_long_operations: '" ) ) {
+		$failures[] = 'gmedia upgrade progress AJAX request must send the long-operation nonce';
+	}
+
+	if ( false === strpos( $update_code, "current_user_can( 'manage_options' )" ) ) {
+		$failures[] = 'gmedia upgrade button must be gated to manage_options';
+	}
+
+	if ( false === strpos( $admin_code, 'current_user_can( \'manage_options\' ) && ( get_transient( \'gmediaUpgrade\' ) || ( \'gmedia\' === $gmCore->_get( \'do_update\' ) ) )' ) ) {
+		$failures[] = 'gmedia update page route must be gated to manage_options';
+	}
+}
+
+if ( $failures ) {
+	echo implode( PHP_EOL, $failures ) . PHP_EOL;
+	exit( 1 );
+}
+
+echo 'Admin AJAX nonce guard passed.' . PHP_EOL;


### PR DESCRIPTION
## Summary
- Require the existing long-operation nonce before the admin maintenance AJAX flow can run.
- Require manage_options before privileged maintenance processing.
- Pass the nonce from the legitimate admin progress UI.
- Add a focused compatibility guard for this nonce/capability pattern.

## Test Plan
- php tests/compat/admin-ajax-nonce-guards.php
- php tests/compat/sql-like-escaping.php
- php tests/compat/no-addslashes-gpc.php
- full PHP syntax lint outside vendor
- git diff --check
- Browser negative smoke: missing and invalid nonce requests returned -1.

Closes #14
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pasyuk/grand-media/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->